### PR TITLE
config(/.gitignore) add yarn.lolock to ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,3 @@ package-lock.json
 
 # yarn.lock
 yarn.lock
-

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ dist
 
 # package-lock.json
 package-lock.json
+
+# yarn.lock
+yarn.lock
+


### PR DESCRIPTION
En linux tengo que instalar las dependencias con yarn, de lo contrario me arroja un error. Solo agregue en el .gitignore la linea para que no suba el archivo yarn.lock. 